### PR TITLE
#2-3ユーザー一覧ページ作成、確認用seedデータ（ユーザー作成）付属

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,9 +80,6 @@ GEM
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.6)
-    jbuilder (2.7.0)
-      activesupport (>= 4.2.0)
-      multi_json (>= 1.2)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -118,11 +115,10 @@ GEM
     mini_magick (4.8.0)
     mini_portile2 (2.2.0)
     minitest (5.10.3)
-    multi_json (1.12.2)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     orm_adapter (0.5.0)
-    pg (0.21.0)
+    pg (0.20.0)
     polyamorous (1.3.1)
       activerecord (>= 3.0)
     pry (0.11.2)
@@ -240,11 +236,10 @@ DEPENDENCIES
   devise
   dotenv-rails
   faker
-  jbuilder (~> 2.0)
   jquery-rails
   kaminari
   mini_magick
-  pg
+  pg (~> 0.20.0)
   pry-byebug
   pry-doc
   pry-rails
@@ -260,4 +255,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,29 @@
+.user_header {
+  margin-bottom: 10px;
+  height: 40px;
+  border-bottom: 1px solid #e4e6e8;
+  white-space: nowrap;
+}
+
+.userlist_boxtable {
+  min-width: 250px;
+  max-width: 250px;
+  min-height: 60px;
+  padding: 5px;
+}
+
+.userlist_boxavatar {
+  float: left;
+  max-width: 48px;
+  max-height: 48px;
+  margin: 7px;
+}
+
+.userlist_boxcontent {
+  padding: 5px;
+}
+
+.userlist_boxend {
+  clear: both;
+  padding-left: 62px;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,9 @@
+class UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+  
+  def show
+    @user = User.find(params[:id])
+  end
+end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Users#index</h1>
+<p>Find me in app/views/users/index.html.erb</p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,2 +1,21 @@
-<h1>Users#index</h1>
-<p>Find me in app/views/users/index.html.erb</p>
+<div class="container">
+  <div class="user_header">
+    <h1>全ユーザー一覧</h1>
+  </div>
+  <div class="row">
+    <% @users.each do |user| %>
+      <div class="userlist_boxtable col-md-3 col-sm-4 col-xs-6 ">
+        <div class="userlist_boxavatar">
+          <%= profile_img(user) %>
+        </div>
+        <div class="userlist_boxcontent">
+          <%= user.name %>
+          <p>貢献度</p>
+        </div>
+        <div class="userlist_boxend">
+          ユーザーtag作るか不明
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 
   resources :questions
   devise_for :users
+
+  resources :users, only: [:index, :show]
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,10 +6,12 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-User.create!(name: Faker::Vehicle.vin,
-             email: Faker::Internet.email,
-             password: "199392199392"
-            )
+10.times do |n|
+  User.create!(name: Faker::Vehicle.vin,
+               email: Faker::Internet.email,
+               password: "199392199392",
+              )
+end
 
 10.times do |note|
   Question.create!( title: Faker::Vehicle.vin,

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionController::TestCase
+  test "should get index" do
+    get :index
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
#2-3

ユーザー一覧ページの作成。
･users/index.html.erb作成
･users.scss作成
参考元に近づける形にしてみました。
再縮小時に、名前が下に回り込むため、
box幅の最低最大幅を固定し、崩れないようにしました。

･seedデータ追記
ローカル確認用に、ユーザーを10だけ作れるよう変更しました。

何か指摘あれば、お願いいたします。