### PR TITLE
質問一覧ページにページネーションを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'carrierwave'
 gem 'mini_magick'
 gem 'rails_12factor', group: :production
 gem 'acts-as-taggable-on', '~> 4.0'
+gem 'kaminari-bootstrap' #ページネーションをBootstrapに対応させるため追加
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
     kaminari-activerecord (1.1.1)
       activerecord
       kaminari-core (= 1.1.1)
+    kaminari-bootstrap (3.0.1)
+      kaminari (>= 0.13.0)
+      rails
     kaminari-core (1.1.1)
     less (2.6.0)
       commonjs (~> 0.2.7)
@@ -241,6 +244,7 @@ DEPENDENCIES
   faker
   jquery-rails
   kaminari
+  kaminari-bootstrap
   mini_magick
   pg (~> 0.20.0)
   pry-byebug

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -80,7 +80,7 @@ body {
   box-sizing: content-box;
   width: 1060px;
   background-color: #FFF;
-  padding: 30px 50px;
+  padding: 50px 50px;
 }
 
 .footer {

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -7,6 +7,7 @@ class QuestionsController < ApplicationController
   # GET /questions.json
   def index
     @questions = Question.page(params[:page]).per(20)
+    @question_count = Question.count
   end
 
   # GET /questions/1

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -6,7 +6,7 @@ class QuestionsController < ApplicationController
   # GET /questions
   # GET /questions.json
   def index
-    @questions = Question.all
+    @questions = Question.page(params[:page]).per(20)
   end
 
   # GET /questions/1

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -52,7 +52,7 @@
       <h4>サイト統計情報</h4>
       <table>
         <tr>
-          <td class="stats-value"><%= @questions.count %></td>
+          <td class="stats-value"><%= @question_count %></td>
           <td class="stats-label">質問</td>
         </tr>
         <tr>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -9,7 +9,7 @@
           <div class="cp clearfix">
             <div class="votes">
               <div class="mini-counts">
-                <span>1</span>
+                <span>1<!-- @question.votes.count--></span>
               </div>
               <div>票</div>
             </div>
@@ -42,6 +42,7 @@
         </div>
       </div>
     <% end %>
+    <%= paginate @questions %>
   </div>
   <div class="sidebar">
     <div class="aside-btn-area">

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -25,7 +25,7 @@
           <table>
             <tr>
               <td>ユーザー名</td>
-              <td>taro</td>
+              <td><%= @question.user.name %></td>
             </tr>
           </table>
         </div>

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@
               )
 end
 
-10.times do |note|
+30.times do |note|
   Question.create!( title: Faker::Vehicle.vin,
                     content: Faker::Vehicle.manufacture,
                     user_id: User.last.id,


### PR DESCRIPTION
#1 -2
変更点
・top.scssを若干変更
・ページネーションをBootstrap対応させるため、gem(kaminari-bootstrap)を追加
・Questionsコントローラーのindexアクションをページネーションへ対応
・showページにユーザー名が表示されるよう変更
・kaminariを日本語対応
・ページネーションの動作確認のため、seedsデータを10件から30件へ変更