### PR TITLE
#4-1 favoriteモデル作成(中間)とuser.questionモデルへ多対多設定

### DIFF
--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,4 @@
+class Favorite < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :question
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,5 +2,7 @@ class Question < ActiveRecord::Base
   belongs_to :user
   has_many :votes, foreign_key: 'question_id', dependent: :destroy
   has_many :vote_users, through: :votes, source: :user
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_users, through: :favorites, source: :user
   acts_as_taggable
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ActiveRecord::Base
   has_many :questions
   has_many :votes, foreign_key: 'user_id', dependent: :destroy
   has_many :vote_questions, through: :votes, source: :question
+  has_many :favorites, dependent: :destroy
 
   def already_voted?(question)
     self.votes.exists?(question_id: question.id)

--- a/db/migrate/20180105013704_create_favorites.rb
+++ b/db/migrate/20180105013704_create_favorites.rb
@@ -1,0 +1,13 @@
+class CreateFavorites < ActiveRecord::Migration
+  def change
+    create_table :favorites do |t|
+      t.integer :user_id
+      t.integer :question_id
+
+      t.timestamps null: false
+    end
+    add_index :favorites, :user_id
+    add_index :favorites, :question_id
+    add_index :favorites, [:user_id, :question_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180101072103) do
+ActiveRecord::Schema.define(version: 20180105013704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "favorites", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "question_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "favorites", ["question_id"], name: "index_favorites_on_question_id", using: :btree
+  add_index "favorites", ["user_id", "question_id"], name: "index_favorites_on_user_id_and_question_id", unique: true, using: :btree
+  add_index "favorites", ["user_id"], name: "index_favorites_on_user_id", using: :btree
 
   create_table "questions", force: :cascade do |t|
     t.string   "title"

--- a/test/fixtures/favorites.yml
+++ b/test/fixtures/favorites.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  question_id: 1
+
+two:
+  user_id: 1
+  question_id: 1

--- a/test/models/favorite_test.rb
+++ b/test/models/favorite_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class FavoriteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#4-1 favoriteモデル+テーブルによる中間テーブル作成

モデル作成、マイグレーションの追記だけになります。
機能は4-2から

- userモデル
has_many :favorites, dependent: :destroy

- questionモデル
has_many :favorites, dependent: :destroy
favorite_users定義（through:favorites経由でUserへ）

- favoriteモデル
user_id question_id によるuniqueを設定。
belongs_to :userと:question