### PR TITLE
#4-4 お気に入りの新旧表示（新規が上に、orderを使う）

### DIFF
--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,4 +1,6 @@
 class Favorite < ActiveRecord::Base
   belongs_to :user
   belongs_to :question
+
+  default_scope -> { order(created_at: :desc)}
 end


### PR DESCRIPTION
#4-4 お気に入りの新旧表示（新規が上に、orderを使う）

・favorite.rb
order→created_atで設定
作成（お気に入り登録）時が、新しい順に並ぶ。