### PR TITLE
Issue#4 2 fix　お気に入りボタンの設置位置変更、お気に入り登録数カウンター追加

### DIFF
--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -184,6 +184,12 @@
   margin: 15px 0 5px 12px;
 }
 
+.favorite_field {
+  margin-top: 10px;
+}
+
+
+
 .edit-delete-btn {
   text-align: right;
 }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -85,9 +85,12 @@
   margin-right: 0 !important;
 }
 
+.favorite_counter {
+  padding-left: 18px;
+}
+
 .star_color_on {
   font-size: 24pt;
-  text-align    : center;
   background    : #FFF;
   color         : #FFD83D;
   border        : none;
@@ -95,7 +98,6 @@
 
 .star_color_off {
   font-size: 24pt;
-  text-align: center;
   background: #FFF;
   color: #000;
   border: none;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -84,3 +84,23 @@
   height: 42px;
   margin-right: 0 !important;
 }
+
+.star_color_on {
+  font-size: 24pt;
+  text-align    : center;
+  background    : #FFF;
+  color         : #FFD83D;
+  border        : none;
+}
+
+.star_color_off {
+  font-size: 24pt;
+  text-align: center;
+  background: #FFF;
+  color: #000;
+  border: none;
+}
+
+.favorite_counter {
+  text-align: center;
+}

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -86,23 +86,33 @@
 }
 
 .favorite_counter {
-  padding-left: 18px;
+  margin-left: 18px;
 }
 
 .star_color_on {
+  padding: 0px 8px;
+  margin-bottom: 0;
   font-size: 24pt;
-  background    : #FFF;
+  background    : transparent;
   color         : #FFD83D;
   border        : none;
 }
 
 .star_color_off {
+  padding: 0px 8px;
+  margin-bottom: 0;
   font-size: 24pt;
-  background: #FFF;
+  background: transparent;
   color: #000;
   border: none;
 }
 
-.favorite_counter {
+.star_self {
+  padding: 0px 8px;
+  margin-bottom: 0;
+  font-size: 24pt;
+  background: transparent;
+  color: #E0E0E0;
+  border: none;
   text-align: center;
 }

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -5,12 +5,15 @@ class FavoritesController < ApplicationController
   def create
     @question = Question.find(params[:favorite][:question_id])
     current_user.favorite!(@question)
+    @favorite_count = Favorite.where(question_id: params[:favorite][:question_id]).count
     respond_with @question
   end
 
   def destroy
     @question = Favorite.find(params[:id]).question
+    count_id = @question.id
     current_user.unfavorite!(@question)
+    @favorite_count = Favorite.where(question_id: count_id).count
     respond_with @question
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -5,7 +5,6 @@ class FavoritesController < ApplicationController
   def create
     @question = Question.find(params[:favorite][:question_id])
     current_user.favorite!(@question)
-    @favorite_count = Favorite.where(question_id: params[:favorite][:question_id]).count
     respond_with @question
   end
 
@@ -13,7 +12,6 @@ class FavoritesController < ApplicationController
     @question = Favorite.find(params[:id]).question
     count_id = @question.id
     current_user.unfavorite!(@question)
-    @favorite_count = Favorite.where(question_id: count_id).count
     respond_with @question
   end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -14,6 +14,7 @@ class QuestionsController < ApplicationController
   def show
     @answer = @question.answers.build
     @answers = @question.answers
+    @favorite_count = Favorite.where(question_id: params[:id]).count
     if user_signed_in?
       @vote = current_user.votes.find_by(question_id: @question.id)
     else

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -14,7 +14,6 @@ class QuestionsController < ApplicationController
   def show
     @answer = @question.answers.build
     @answers = @question.answers
-    @favorite_count = Favorite.where(question_id: params[:id]).count
     if user_signed_in?
       @vote = current_user.votes.find_by(question_id: @question.id)
     else

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -4,9 +4,6 @@
     <!-- <h1>質問タイトル</h1> questionコントローラーから取得 -->
     <h1><%= @question.title %></h1>
   </div>
-  <% if user_signed_in? %>
-    <%= render 'users/favorite_form', question: @question %>
-  <% end %>
   <div class="mainbar">
     <div class="question-area">
       <div class="edit-delete-btn">
@@ -22,6 +19,11 @@
           <span class="vote-count"><%= @question.votes.count %></span>
           <p>投票数</p>
           <%= link_to image_tag('/down-arrow.png'), question_votes_path(@question), method: :delete %>
+          <% if user_signed_in? %>
+            <div class="favorite_field">
+              <%= render 'users/favorite_form', question: @question %>
+            </div>
+          <% end %>
         </div>
         <div class="post-text">
           <p><%= @question.content %></p>

--- a/app/views/users/_favorite_form.html.erb
+++ b/app/views/users/_favorite_form.html.erb
@@ -1,13 +1,17 @@
 <div id="favorite_form_<%= question.id %>">
-  <% unless current_user.favoriteing?(question) %>
-    <%= form_for(current_user.favorites.build(question_id: question.id), remote: true) do |f| %>
-      <%= f.hidden_field :question_id %>
-      <%= f.submit "☆", class: "star_color_off" %>
+  <% if question.user_id != current_user.id %>
+    <% unless current_user.favoriteing?(question) %>
+      <%= form_for(current_user.favorites.build(question_id: question.id), remote: true) do |f| %>
+        <%= f.hidden_field :question_id %>
+        <%= f.submit "☆", class: "star_color_off" %>
+      <% end %>
+    <% else %>
+      <%= form_for(current_user.favorites.find_by(question_id: question.id), html: { method: :delete }, remote: true) do |f| %>
+        <%= f.submit "★", class: "star_color_on" %>
+      <% end %>
     <% end %>
   <% else %>
-    <%= form_for(current_user.favorites.find_by(question_id: question.id), html: { method: :delete }, remote: true) do |f| %>
-      <%= f.submit "★", class: "star_color_on" %>
-    <% end %>
+    <p class="star_self">★</p>
   <% end %>
-  <p class="favorite_counter"><%= @favorite_count %></p>
+  <p class="favorite_counter"><%= question.favorites.count %></p>
 </div>

--- a/app/views/users/_favorite_form.html.erb
+++ b/app/views/users/_favorite_form.html.erb
@@ -2,11 +2,12 @@
   <% unless current_user.favoriteing?(question) %>
     <%= form_for(current_user.favorites.build(question_id: question.id), remote: true) do |f| %>
       <%= f.hidden_field :question_id %>
-      <%= f.submit "お気に入り", class: "btn btn-large btn-primary" %>
+      <%= f.submit "☆", class: "star_color_off" %>
     <% end %>
   <% else %>
     <%= form_for(current_user.favorites.find_by(question_id: question.id), html: { method: :delete }, remote: true) do |f| %>
-      <%= f.submit "お気に入り解除", class: "btn btn-large" %>
+      <%= f.submit "★", class: "star_color_on" %>
     <% end %>
   <% end %>
+  <p class="favorite_counter"><%= @favorite_count %></p>
 </div>


### PR DESCRIPTION
#4-2fix

・質問詳細にお気に入りボタン設置、デザイン変更にあたります。
正式な設置場所、投票機能の下へ、
gosaru6さんと相談の上設置したため、pushログがあります。

・お気に入り登録数カウント設置
1．コントローラーで変数用意したが不要になったため、再修正
（question.favorites.countで、対象のquestionレコードから呼び出せたため。）
users/favorite_formへ表示を追記

・変更点
質問詳細に設置していた、「お気に入り」ボタンを「☆」化
質問のユーザーid、カレントユーザーid一致で灰色（押せない）へ