### PR TITLE
#4-5　seedデータ追加

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,19 +6,59 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-10.times do |n|
-  User.create!(name: Faker::Vehicle.vin,
+50.times do |n|
+  User.create!(name: Faker::Name.name,
                email: Faker::Internet.email,
                password: "199392199392",
               )
 end
 
-30.times do |note|
+60.times do |note|
+  user_id =  rand(2..20)
   Question.create!( title: Faker::Vehicle.vin,
                     content: Faker::Vehicle.manufacture,
-                    user_id: User.last.id,
-                    )
+                    user_id: user_id,
+                  )
 end
+
+1.times do |o|
+  user_id =  1
+  44.times do |m|
+  question_id = o + m + 1
+  Question.create!( title: Faker::Vehicle.vin,
+                    content: Faker::Vehicle.manufacture,
+                    user_id: user_id,
+                  )
+  Favorite.create!( user_id: user_id,
+                    question_id: question_id,
+                  )
+  Vote.create!( user_id: user_id,
+                question_id: question_id,
+              )
+  Answer.create!( user_id: user_id,
+                  question_id: question_id,
+                  content: Faker::Lorem.sentence,
+                  )
+  end
+end
+
+10.times do |h|
+  user_id =  h + 2
+  10.times do |i|
+  question_id = h + i + 1
+  Favorite.create!( user_id: user_id,
+                    question_id: question_id,
+                  )
+  Vote.create!( user_id: user_id,
+                question_id: question_id,
+              )
+  Answer.create!( user_id: user_id,
+                  question_id: question_id,
+                  content: Faker::Lorem.sentence,
+                  )
+  end
+end
+
 
 ##stackoverflow_tags.csvをdbにインポート
 # require "csv"


### PR DESCRIPTION
#4-5　

bundle exec rake db:migrate:reset
bundle exec rake db:seed

windows環境でエラー対策のため、bundle execつけてます。
リセット後マイグレーション、
テスト用データ大量作成です。

・seeds.rb概要
おおまかに4つ、全体と個人確認(user_id1)用のデータ
１．２　ページネーション確認のため、各最低20以上作成。

３．ユーザーID1をメインとしたデータ44件
ユーザー一覧のページネーション、
ユーザー詳細内の各ページネーションの確認用。

４．投票数や回答確認用にランダム設定
TOPページの質問一覧、投票数のorder確認が可能。
投票数は最大11がある。

・seeds.rb内訳
1.ユーザー作成(50名)
2.質問作成(60件)
ユーザーID、2～20でランダムのみ

3.ユーザーID(1固定)で44件
質問、お気に入り、投票、アンサーを作成

4.ユーザーIDをずらし、上記を作成
ID2～12の範囲で各10件、3と同じものを作成
