### PR TITLE
【fixed】#4-4 order(created_at)、モデル内で行わず、コントローラー内で行うよう変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,8 @@ class UsersController < ApplicationController
       @check_list = "質問一覧"
     elsif @check_list == "お気に入り一覧"
       favorites_data = Favorite.where(user_id: params[:id])
-      @favorites = favorites_data.page(params[:page]).per(20)
+      favorites_data_order = favorites_data.order(:created_at).reverse_order
+      @favorites = favorites_data_order.page(params[:page]).per(20)
     else
       @question = Question.where(user_id: params[:id])
       @answers = Answer.where(user_id: params[:id])

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,6 +1,4 @@
 class Favorite < ActiveRecord::Base
   belongs_to :user
   belongs_to :question
-
-  default_scope -> { order(created_at: :desc)}
 end


### PR DESCRIPTION
#4-4

・お気に入り、created_at対象に新が上にくるソート
default_scope問題の提示がありましたので、
favorite.rbから除外し、
userscontroller内でreverse_orderにより実行するよう変更しました。
